### PR TITLE
Compatible with e2e redirect to third-party site sourcemap parsing error

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -193,7 +193,11 @@ export async function convertToIstanbulCoverage(
       },
     );
 
-    await convertor.load();
+    try {
+      await convertor.load();
+    } catch (error) {
+      continue;
+    }
 
     convertor.applyCoverage(script.functions);
 


### PR DESCRIPTION
When using e2e testing to jump to a third-party site, the coverage of the opened third-party site is parsed back, but some of the amd static resources they load do not have a sourcemap, resulting in an error during load() execution and the inability to generate a coverage report