### PR TITLE
Improve sourceMappingURL regex

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -44,7 +44,7 @@ export async function getSourceMap(
   url: string,
   source: string,
 ): Promise<EncodedSourceMap | undefined> {
-  const match = source.match(/\/\/# *sourceMappingURL=(.*)/);
+  const match = source.match(/\s\/\/# *sourceMappingURL=(.*)/);
 
   if (match == null) {
     try {


### PR DESCRIPTION
In my case, the build generated by webpack contained two references to `sourceMappingURL` that matched the existing regex.

The first one was in the middle of the minified script, looked something like `... 10)+1,l=R.substring(V)+(B?"//# sourceMappingURL="+B:""),J=new Blob([l],{type:"application/javascript"});...`

The second one was the expected one at the very end of the file.

`getSourceMap` stopped at the first match, so ended up not finding the correct one.

Matching for a preceding newline before the `//# sourceMappingURL` comment resolves this, as it finds the correct comment and I get proper coverage reports now.

An alternative approach / further improvement would be to use a global match, eg.

```js
const matches = source.match(/\s\/\/# *sourceMappingURL=(.*)/g);
const match = matches.at(-1);
```