### PR TITLE
make collectionCoverage a configurable option

### DIFF
--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -20,7 +20,7 @@ const coverageFixtures: Fixtures<
   PlaywrightTestArgs & PlaywrightTestOptions,
   PlaywrightWorkerArgs & PlaywrightWorkerOptions
 > = {
-  collectCoverage: true,
+  collectCoverage: [true, { option: true } ],
 
   page: async ({page, collectCoverage, browserName}, use, testInfo) => {
     if (browserName !== 'chromium' || !collectCoverage) {


### PR DESCRIPTION
The option needs to be a tuple as described here:
https://playwright.dev/docs/test-fixtures#fixtures-options

Without this, settings in playwright.config do not have any effect.